### PR TITLE
Revert "Bump golang from 1.24.6-bullseye to 1.25rc3-bullseye (#119)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25rc3-bullseye AS builder
+FROM golang:1.24.6-bullseye AS builder
 WORKDIR /base
 COPY . .
 RUN make clean-build


### PR DESCRIPTION
This reverts commit b851d691a9a6a35c93a6af1bfd0ee4f0f8a41c32.